### PR TITLE
[Feature] 관리자 페이지의 초기 폴더 구조 및 라우팅을 구성

### DIFF
--- a/src/components/auth/ProtectedRoute.tsx
+++ b/src/components/auth/ProtectedRoute.tsx
@@ -1,8 +1,18 @@
-import { Navigate, Outlet } from 'react-router-dom';
-import { useAuthStore } from '@/stores/useAuthStore'; 
+import { Navigate } from 'react-router-dom';
+import { useAuthStore } from '@/stores/useAuthStore';
 
-export default function ProtectedRoute() {
-  const isLoggedIn = useAuthStore((state) => state.isLoggedIn);
-
-  return isLoggedIn ? <Outlet /> : <Navigate to="/" replace />;
+interface Props {
+  children: React.ReactNode;
 }
+
+const ProtectedRoute = ({ children }: Props) => {
+  const isLoggedIn = useAuthStore((state) => state.isAdminLoggedIn);
+
+  if (!isLoggedIn) {
+    return <Navigate to="/admin" replace />;
+  }
+
+  return <>{children}</>;
+};
+
+export default ProtectedRoute;

--- a/src/pages/admin/AdminPage.tsx
+++ b/src/pages/admin/AdminPage.tsx
@@ -1,6 +1,21 @@
-const AdminPage = () => {
-    return <div>관리자 전용 페이지입니다.</div>;
+import { useAuthStore } from '@/stores/useAuthStore';
+import { useNavigate } from 'react-router-dom';
+
+const AdminLoginPage = () => {
+  const login = useAuthStore((state) => state.login);
+  const navigate = useNavigate();
+
+  const handleLogin = () => {
+    login();
+    navigate('/admin/booth');
   };
-  
-  export default AdminPage;
-  
+
+  return (
+    <div>
+      <h2>관리자 로그인</h2>
+      <button onClick={handleLogin}>로그인</button>
+    </div>
+  );
+};
+
+export default AdminLoginPage;

--- a/src/pages/admin/booth/app/BoothAdminAppView.tsx
+++ b/src/pages/admin/booth/app/BoothAdminAppView.tsx
@@ -1,0 +1,13 @@
+
+
+const BoothAdminAppView = () => {
+  return (
+    <div style={{ padding: '16px' }}>
+      <h2>📱 부스 관리자 앱뷰</h2>
+      <p>현재 접속 기기는 모바일입니다.</p>
+      {/* 부스 리스트 / 대기자 목록 / 입장 처리 등 이후 구현 */}
+    </div>
+  );
+};
+
+export default BoothAdminAppView;

--- a/src/pages/admin/booth/index.tsx
+++ b/src/pages/admin/booth/index.tsx
@@ -1,0 +1,9 @@
+import BoothAdminAppView from './app/BoothAdminAppView';
+import BoothAdminWebView from './web/BoothAdminWebView';
+
+const BoothAdminEntry = () => {
+  const isMobile = /iPhone|Android/i.test(navigator.userAgent);
+  return isMobile ? <BoothAdminAppView /> : <BoothAdminWebView />;
+};
+
+export default BoothAdminEntry;

--- a/src/pages/admin/booth/web/BoothAdminWebView.tsx
+++ b/src/pages/admin/booth/web/BoothAdminWebView.tsx
@@ -1,0 +1,13 @@
+
+
+const BoothAdminWebView = () => {
+  return (
+    <div style={{ padding: '24px' }}>
+      <h2>💻 부스 관리자 웹뷰</h2>
+      <p>현재 접속 기기는 데스크탑입니다.</p>
+      {/* 부스별 대기자 확인 / 상태 변경 등 이후 구현 */}
+    </div>
+  );
+};
+
+export default BoothAdminWebView;

--- a/src/pages/admin/notice/index.tsx
+++ b/src/pages/admin/notice/index.tsx
@@ -1,0 +1,11 @@
+const AdminNoticePage = () => {
+    return (
+      <div style={{ padding: '24px' }}>
+        <h2>🛠️ 관리자용 공지 관리</h2>
+        <p>공지사항 관리 기능이 여기에 들어갑니다.</p>
+      </div>
+    );
+  };
+  
+  export default AdminNoticePage;
+  

--- a/src/pages/admin/notice/lost.tsx
+++ b/src/pages/admin/notice/lost.tsx
@@ -1,0 +1,11 @@
+const AdminLostPage = () => {
+    return (
+      <div style={{ padding: '24px' }}>
+        <h2>🎒 관리자용 분실물 관리</h2>
+        <p>분실물 관리 기능이 여기에 들어갑니다.</p>
+      </div>
+    );
+  };
+  
+  export default AdminLostPage;
+  

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,37 +1,64 @@
-import { createBrowserRouter } from "react-router-dom";
-import Layout from "@/components/layout/Layout";
-import ProtectedRoute from "@/components/auth/ProtectedRoute";
+import { createBrowserRouter } from 'react-router-dom';
+import Layout from '@/components/layout/Layout';
+import ProtectedRoute from '@/components/auth/ProtectedRoute';
 
-import HomePage from "@/pages/home/HomePage";
-import TimetablePage from "@/pages/timetable/TimetablePage";
-import NoticePage from "@/pages/notice/NoticePage";
-import BoothPage from "@/pages/booth/BoothPage";
-import WaitingPage from "@/pages/waiting/WaitingPage";
-import NotFoundPage from "@/pages/not-found/NotFoundPage";
-import AdminPage from "@/pages/admin/AdminPage";
-import NoticeDetailPage from "@/pages/notice-detail/NoticeDetailPage";
-import LostDetailPage from "@/pages/lost-detail/LostDetailPage";
-import BoothDetailPage from "@/pages/booth/BoothDetailPage";
+import HomePage from '@/pages/home/HomePage';
+import TimetablePage from '@/pages/timetable/TimetablePage';
+import NoticePage from '@/pages/notice/NoticePage';
+import BoothPage from '@/pages/booth/BoothPage';
+import WaitingPage from '@/pages/waiting/WaitingPage';
+import NotFoundPage from '@/pages/not-found/NotFoundPage';
+import NoticeDetailPage from '@/pages/notice-detail/NoticeDetailPage';
+import LostDetailPage from '@/pages/lost-detail/LostDetailPage';
+import BoothDetailPage from '@/pages/booth/BoothDetailPage';
+
+import AdminLoginPage from '@/pages/admin/AdminPage';
+import BoothAdminEntry from '@/pages/admin/booth';
+import AdminNoticePage from '@/pages/admin/notice';
+import AdminLostPage from '@/pages/admin/notice/lost';
 
 export const router = createBrowserRouter([
   {
-    path: "/",
+    path: '/',
     element: <Layout />,
     children: [
       { index: true, element: <HomePage /> },
-      { path: "timetable", element: <TimetablePage /> },
-      { path: "notice", element: <NoticePage /> },
-      { path: "booth", element: <BoothPage /> },
-      { path: "booth/:id", element: <BoothDetailPage /> },
-      { path: "waiting", element: <WaitingPage /> },
-      {
-        path: "admin",
-        element: <ProtectedRoute />,
-        children: [{ index: true, element: <AdminPage /> }],
-      },
-      { path: "notice/:id", element: <NoticeDetailPage /> },
-      { path: "notice/lost/:id", element: <LostDetailPage /> },
-      { path: "*", element: <NotFoundPage /> },
+      { path: 'timetable', element: <TimetablePage /> },
+      { path: 'notice', element: <NoticePage /> },
+      { path: 'notice/:id', element: <NoticeDetailPage /> },
+      { path: 'notice/lost/:id', element: <LostDetailPage /> },
+      { path: 'booth', element: <BoothPage /> },
+      { path: 'booth/:id', element: <BoothDetailPage /> },
+      { path: 'waiting', element: <WaitingPage /> },
+      { path: '*', element: <NotFoundPage /> },
     ],
+  },
+  {
+    path: '/admin',
+    element: <AdminLoginPage />,
+  },
+  {
+    path: '/admin/booth',
+    element: (
+      <ProtectedRoute>
+        <BoothAdminEntry />
+      </ProtectedRoute>
+    ),
+  },
+  {
+    path: '/admin/notice',
+    element: (
+      <ProtectedRoute>
+        <AdminNoticePage />
+      </ProtectedRoute>
+    ),
+  },
+  {
+    path: '/admin/notice/lost',
+    element: (
+      <ProtectedRoute>
+        <AdminLostPage />
+      </ProtectedRoute>
+    ),
   },
 ]);

--- a/src/stores/useAuthStore.ts
+++ b/src/stores/useAuthStore.ts
@@ -1,15 +1,13 @@
-// 관리자 페이지에서 로그인 상태를 관리하기 위한 임시 스토어입니다.
-
 import { create } from 'zustand';
 
 interface AuthState {
-  isLoggedIn: boolean;
+  isAdminLoggedIn: boolean;
   login: () => void;
   logout: () => void;
 }
 
 export const useAuthStore = create<AuthState>((set) => ({
-  isLoggedIn: false,
-  login: () => set({ isLoggedIn: true }),
-  logout: () => set({ isLoggedIn: false }),
+  isAdminLoggedIn: false,
+  login: () => set({ isAdminLoggedIn: true }),
+  logout: () => set({ isAdminLoggedIn: false }),
 }));


### PR DESCRIPTION
## ✨ 변경사항 요약

- 관리자 페이지 전용 폴더 구조 정리 및 라우팅 구성
- 로그인 여부에 따라 /admin/booth 접근 제한 (ProtectedRoute)
- 상태 관리용 useAuthStore (Zustand) 도입
- 모바일/데스크탑 기기 분기에 따라 서로 다른 뷰 렌더링
- /admin/notice, /admin/notice/lost 페이지 생성 및 보호 라우팅 적용

## 📂 관련 이슈

- #23 

## ✅ 작업 내용 체크리스트

- [ ] 기능 구현 완료
- [ ] UI 확인
- [ ] ESLint/Prettier 적용
- [ ] 테스트 또는 동작 확인 완료

## 📸 스크린샷 (선택)

없음

## 🙋 기타 참고 사항

없음